### PR TITLE
Investigate missing withdrawal button for bonus balance

### DIFF
--- a/bot/handlers/userHandlers.js
+++ b/bot/handlers/userHandlers.js
@@ -207,9 +207,10 @@ class UserHandlers {
           "my_referrals"
         ),
       ];
-      // Only show Balance & Withdraw if user has balance > 0
+      // Only show Balance & Withdraw if user has balance > 0 (check both coinBalance and referralBalance)
+      const totalBalance = (user.coinBalance || 0) + (user.referralBalance || 0);
       const mainRow2 =
-        user.coinBalance > 0
+        totalBalance > 0
           ? [
               Markup.button.callback(
                 t("btn_balance_withdraw", {}, userLanguage),


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update withdrawal button visibility to include referral balance, ensuring users with bonus balance can see the button.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the withdrawal button only appeared if `user.coinBalance > 0`. However, some users have their balance stored in `user.referralBalance` (bonus balance). This change ensures that the button is visible if either `coinBalance` or `referralBalance` (or both) is greater than zero, aligning button visibility with the actual withdrawal logic which already uses `referralBalance`.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbb3df5f-7adf-471e-bbf0-bcf90b07b823">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbb3df5f-7adf-471e-bbf0-bcf90b07b823">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>